### PR TITLE
fix: handle negative SAE acts when normalizing

### DIFF
--- a/sae_probes/run_sae_evals.py
+++ b/sae_probes/run_sae_evals.py
@@ -100,17 +100,20 @@ def get_sorted_indices(X_train_sae, y_train):
 
 
 def get_sorted_indices_new(X_train_sae, y_train):
-    col_sums = X_train_sae.sum(dim=0)
-    col_nonzero_counts = (X_train_sae != 0).sum(dim=0)
-    col_means = col_sums / (col_nonzero_counts + 1e-6)
-
-    # Divide each col by the average of the col
-    X_train_sae_normalized = X_train_sae / (col_means + 1e-6)
+    X_train_sae_normalized = normalize_sae_activations(X_train_sae)
     X_train_diff = X_train_sae_normalized[y_train == 1].mean(
         dim=0
     ) - X_train_sae_normalized[y_train == 0].mean(dim=0)
     sorted_indices = torch.argsort(torch.abs(X_train_diff), descending=True)
     return sorted_indices
+
+
+def normalize_sae_activations(X_sae):
+    # take abs to handle negative values in the SAE activations for novel architectures.
+    col_sums = X_sae.abs().sum(dim=0)
+    col_nonzero_counts = (X_sae != 0).sum(dim=0)
+    col_means = col_sums / (col_nonzero_counts + 1e-6)
+    return X_sae / (col_means + 1e-6)
 
 
 def run_sae_eval(

--- a/tests/test_run_sae_evals.py
+++ b/tests/test_run_sae_evals.py
@@ -2,17 +2,124 @@ import json
 from pathlib import Path
 
 import pytest
+import torch
 from sae_lens import SAE
 from transformer_lens import HookedTransformer
 
 from sae_probes.constants import RegType, Setting
-from sae_probes.run_sae_evals import get_save_metrics_path, run_sae_eval, run_sae_evals
+from sae_probes.run_sae_evals import (
+    get_save_metrics_path,
+    normalize_sae_activations,
+    run_sae_eval,
+    run_sae_evals,
+)
 from sae_probes.utils_data import (
     get_class_imbalance,
     get_dataset_sizes,
     get_training_sizes,
 )
 from tests.helpers import TEST_DATASET_NAME, generate_model_activations
+
+
+def test_normalize_sae_activations_basic() -> None:
+    # Test basic normalization with positive values
+    X_sae = torch.tensor([[1.0, 2.0, 0.0], [2.0, 0.0, 3.0], [0.0, 4.0, 6.0]])
+
+    result = normalize_sae_activations(X_sae)
+
+    # Check that result has same shape
+    assert result.shape == X_sae.shape
+
+    # Manually calculate expected values
+    # Column 0: values [1.0, 2.0, 0.0], non-zero count = 2, sum = 3.0, mean = 1.5
+    # Column 1: values [2.0, 0.0, 4.0], non-zero count = 2, sum = 6.0, mean = 3.0
+    # Column 2: values [0.0, 3.0, 6.0], non-zero count = 2, sum = 9.0, mean = 4.5
+
+    expected = torch.tensor(
+        [
+            [1.0 / 1.5, 2.0 / 3.0, 0.0 / 4.5],
+            [2.0 / 1.5, 0.0 / 3.0, 3.0 / 4.5],
+            [0.0 / 1.5, 4.0 / 3.0, 6.0 / 4.5],
+        ]
+    )
+
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_normalize_sae_activations_with_negative_values() -> None:
+    # Test that negative values are handled correctly (abs is taken)
+    X_sae = torch.tensor([[-1.0, 2.0, 0.0], [2.0, 0.0, -3.0], [0.0, -4.0, 6.0]])
+
+    result = normalize_sae_activations(X_sae)
+
+    # Check that result has same shape
+    assert result.shape == X_sae.shape
+
+    # Manually calculate expected values using abs for means
+    # Column 0: abs values [1.0, 2.0, 0.0], non-zero count = 2, sum = 3.0, mean = 1.5
+    # Column 1: abs values [2.0, 0.0, 4.0], non-zero count = 2, sum = 6.0, mean = 3.0
+    # Column 2: abs values [0.0, 3.0, 6.0], non-zero count = 2, sum = 9.0, mean = 4.5
+
+    expected = torch.tensor(
+        [
+            [-1.0 / 1.5, 2.0 / 3.0, 0.0 / 4.5],
+            [2.0 / 1.5, 0.0 / 3.0, -3.0 / 4.5],
+            [0.0 / 1.5, -4.0 / 3.0, 6.0 / 4.5],
+        ]
+    )
+
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_normalize_sae_activations_all_zeros_column() -> None:
+    # Test handling of columns with all zeros
+    X_sae = torch.tensor([[1.0, 0.0, 2.0], [2.0, 0.0, 0.0], [0.0, 0.0, 4.0]])
+
+    result = normalize_sae_activations(X_sae)
+
+    # Check that result has same shape
+    assert result.shape == X_sae.shape
+
+    # Column 1 has all zeros, so col_means[1] = 0 / (0 + 1e-6) = 0
+    # Division by (0 + 1e-6) should give very large values
+    # Column 0: mean = 3.0/2 = 1.5
+    # Column 2: mean = 6.0/2 = 3.0
+
+    expected = torch.tensor(
+        [
+            [1.0 / 1.5, 0.0 / 1e-6, 2.0 / 3.0],
+            [2.0 / 1.5, 0.0 / 1e-6, 0.0 / 3.0],
+            [0.0 / 1.5, 0.0 / 1e-6, 4.0 / 3.0],
+        ]
+    )
+
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_normalize_sae_activations_single_row() -> None:
+    # Test with single row
+    X_sae = torch.tensor([[1.0, 2.0, 0.0, -3.0]])
+
+    result = normalize_sae_activations(X_sae)
+
+    # Each column has at most one non-zero value, so means are just the abs values
+    expected = torch.tensor([[1.0 / 1.0, 2.0 / 2.0, 0.0 / 1e-6, -3.0 / 3.0]])
+
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_normalize_sae_activations_single_column() -> None:
+    # Test with single column
+    X_sae = torch.tensor([[1.0], [0.0], [2.0], [-1.0]])
+
+    result = normalize_sae_activations(X_sae)
+
+    # Column has values [1.0, 0.0, 2.0, -1.0], abs sum = 4.0, non-zero count = 3, mean = 4.0/3
+    expected = torch.tensor(
+        [[1.0 / (4.0 / 3)], [0.0 / (4.0 / 3)], [2.0 / (4.0 / 3)], [-1.0 / (4.0 / 3)]]
+    )
+
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize("reg_type", ["l1", "l2"])


### PR DESCRIPTION
This PR takes the absolute value of activations when calculating their mean for normalizing mean-diff sorting. This should have no effect for current SAEs, but should help avoid dividing by 0 for SAEs that can take on negative activation values, like [AbsTopK SAEs](https://arxiv.org/abs/2510.00404). 